### PR TITLE
Proposed changes for easier pickin's

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "version": "1.3.2",
   "scripts": {
-    "postinstall": "./node_modules/bower/bin/bower install ./node_modules/livefyre-bootstrap/bower.json",
+    "postinstall": "../bower/bin/bower install ../livefyre-bootstrap/bower.json",
     "start": "./bin/server.js",
     "test": "./bin/test",
     "hint": "./node_modules/jshint/bin/jshint src; echo",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "version": "1.3.2",
   "scripts": {
-    "postinstall": "./node_modulels/bower/bin/bower install",
+    "postinstall": "./node_modules/bower/bin/bower install",
     "start": "./bin/server.js",
     "test": "./bin/test",
     "hint": "./node_modules/jshint/bin/jshint src; echo",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "version": "1.3.2",
   "scripts": {
-    "postinstall": "./node_modules/bower/bin/bower install",
+    "postinstall": "../node_modules/bower/bin/bower install ./node_modules/livefyre-bootstrap/bower.json",
     "start": "./bin/server.js",
     "test": "./bin/test",
     "hint": "./node_modules/jshint/bin/jshint src; echo",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "version": "1.3.2",
   "scripts": {
-    "postinstall": "../node_modules/bower/bin/bower install ./node_modules/livefyre-bootstrap/bower.json",
+    "postinstall": "./node_modules/bower/bin/bower install ./node_modules/livefyre-bootstrap/bower.json",
     "start": "./bin/server.js",
     "test": "./bin/test",
     "hint": "./node_modules/jshint/bin/jshint src; echo",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "version": "1.3.2",
   "scripts": {
-    "postinstall": "../bower/bin/bower install ../livefyre-bootstrap/bower.json",
+    "postinstall": "./node_modulels/bower/bin/bower install",
     "start": "./bin/server.js",
     "test": "./bin/test",
     "hint": "./node_modules/jshint/bin/jshint src; echo",

--- a/src/styles/alerts.less
+++ b/src/styles/alerts.less
@@ -1,6 +1,3 @@
-@import (reference) "./mixins";
-@import (reference) "./variables";
-
 .lf-alert {
   padding: @alert-padding;
   margin-bottom: @line-height-computed;

--- a/src/styles/all.less
+++ b/src/styles/all.less
@@ -1,8 +1,9 @@
-@import (reference) "./mixins";
+@bootstrap-less: "../../bootstrap/less";
 @import (reference) "./variables";
+@import (reference) "./mixins";
 
 .lf {
-	@import "../../lib/bootstrap/less/bootstrap";
+	@import "@{bootstrap-less}/bootstrap";
 
     /**
      * Livefyre stuff

--- a/src/styles/all.less
+++ b/src/styles/all.less
@@ -2,7 +2,7 @@
 @import (reference) "./variables";
 
 .lf {
-	@import "/lib/bootstrap/less/bootstrap";
+	@import "../../lib/bootstrap/less/bootstrap";
 
     /**
      * Livefyre stuff

--- a/src/styles/badges.less
+++ b/src/styles/badges.less
@@ -1,5 +1,3 @@
-@import (reference) "./variables";
-
 .lf-badge {
   display: inline-block;
   min-width: 10px;

--- a/src/styles/bar.less
+++ b/src/styles/bar.less
@@ -1,4 +1,4 @@
-@import (reference) "/lib/bootstrap/less/navs";
+@import (reference) "../../lib/bootstrap/less/navs";
 @import (reference) "./mixins";
 @import (reference) "./variables";
 

--- a/src/styles/bar.less
+++ b/src/styles/bar.less
@@ -1,6 +1,4 @@
-@import (reference) "../../lib/bootstrap/less/navs";
-@import (reference) "./mixins";
-@import (reference) "./variables";
+@import (reference) "@{bootstrap-less}/navs";
 
 /**
  * A bar of things, usually buttons, but without all the

--- a/src/styles/button-groups.less
+++ b/src/styles/button-groups.less
@@ -1,6 +1,4 @@
-@import (reference) "../../lib/bootstrap/less/button-groups";
-@import (reference) "./variables";
-@import (reference) "./mixins";
+@import (reference) "@{bootstrap-less}/button-groups";
 @import (reference) "./buttons";
 
 //

--- a/src/styles/button-groups.less
+++ b/src/styles/button-groups.less
@@ -1,4 +1,4 @@
-@import (reference) "/lib/bootstrap/less/button-groups";
+@import (reference) "../../lib/bootstrap/less/button-groups";
 @import (reference) "./variables";
 @import (reference) "./mixins";
 @import (reference) "./buttons";

--- a/src/styles/buttons.less
+++ b/src/styles/buttons.less
@@ -1,4 +1,4 @@
-@import (reference) "/lib/bootstrap/less/buttons";
+@import (reference) "../../lib/bootstrap/less/buttons";
 @import (reference) "./mixins";
 @import (reference) "./variables";
 

--- a/src/styles/buttons.less
+++ b/src/styles/buttons.less
@@ -1,6 +1,4 @@
-@import (reference) "../../lib/bootstrap/less/buttons";
-@import (reference) "./mixins";
-@import (reference) "./variables";
+@import (reference) "@{bootstrap-less}/buttons";
 
 .lf-btn {
     .btn();

--- a/src/styles/close.less
+++ b/src/styles/close.less
@@ -1,6 +1,3 @@
-@import (reference) "./mixins";
-@import (reference) "./variables";
-
 .lf-close {
   box-sizing: border-box;
   height: @close-height;

--- a/src/styles/dropdowns.less
+++ b/src/styles/dropdowns.less
@@ -1,6 +1,3 @@
-@import (reference) "./mixins";
-@import (reference) "./variables";
-
 //
 // Dropdown menus
 // --------------------------------------------------

--- a/src/styles/forms.less
+++ b/src/styles/forms.less
@@ -1,6 +1,3 @@
-@import (reference) "./variables";
-@import (reference) "./mixins";
-
 fieldset {
     padding: 0;
     margin: 0;

--- a/src/styles/fycon-chars.less
+++ b/src/styles/fycon-chars.less
@@ -1,5 +1,3 @@
-@import (reference) "./variables";
-
 @charset "UTF-8";
 
 .fycon-action-etc {

--- a/src/styles/fycon-styles.less
+++ b/src/styles/fycon-styles.less
@@ -1,4 +1,3 @@
-@import (reference) "./variables";
 @fycon-font-version: "1.3.1";
 
 @font-face {

--- a/src/styles/labels.less
+++ b/src/styles/labels.less
@@ -1,6 +1,3 @@
-@import (reference) "./variables";
-@import (reference) "./mixins";
-
 .lf-label {
   display: inline;
   padding: .2em .5em;

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -1,4 +1,4 @@
-@import (reference) "/lib/bootstrap/less/mixins.less";
+@import (reference) "../../lib/bootstrap/less/mixins.less";
 
 // Button variants
 // -------------------------

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -1,4 +1,4 @@
-@import (reference) "../../lib/bootstrap/less/mixins.less";
+//@import (reference) "@{bootstrap-less}/mixins.less";
 
 // Button variants
 // -------------------------

--- a/src/styles/navbar.less
+++ b/src/styles/navbar.less
@@ -1,8 +1,6 @@
-@import (reference) "./mixins";
-@import (reference) "./variables";
-@import (reference) "../../lib/bootstrap/less/forms";
-@import (reference) "../../lib/bootstrap/less/utilities";
-@import (reference) "../../lib/bootstrap/less/navbar";
+@import (reference) "@{bootstrap-less}/forms";
+@import (reference) "@{bootstrap-less}/utilities";
+@import (reference) "@{bootstrap-less}/navbar";
 
 .lf-navbar {
     .navbar;

--- a/src/styles/navbar.less
+++ b/src/styles/navbar.less
@@ -1,8 +1,8 @@
 @import (reference) "./mixins";
 @import (reference) "./variables";
-@import (reference) "/lib/bootstrap/less/forms";
-@import (reference) "/lib/bootstrap/less/utilities";
-@import (reference) "/lib/bootstrap/less/navbar";
+@import (reference) "../../lib/bootstrap/less/forms";
+@import (reference) "../../lib/bootstrap/less/utilities";
+@import (reference) "../../lib/bootstrap/less/navbar";
 
 .lf-navbar {
     .navbar;

--- a/src/styles/popovers.less
+++ b/src/styles/popovers.less
@@ -1,6 +1,3 @@
-@import (reference) "./mixins";
-@import (reference) "./variables";
-
 /**
 * Themes an .lf-popover
 * @mixin

--- a/src/styles/toggles.less
+++ b/src/styles/toggles.less
@@ -1,5 +1,3 @@
-@import (reference) "./variables";
-
 /* Toggle styles (to be used with toggles.js)
 -------------------------------------------------- */
 

--- a/src/styles/tooltip.less
+++ b/src/styles/tooltip.less
@@ -1,6 +1,3 @@
-@import (reference) "./mixins";
-@import (reference) "./variables";
-
 /**
 * Themes an .lf-tooltip
 * @mixin

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -1,7 +1,7 @@
 /**
  * Bootstrap Variables
  */
-@import "../../lib/bootstrap/less/variables.less";
+@import "@{bootstrap-less}/variables.less";
 
 
 // LF colors

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -1,7 +1,7 @@
 /**
  * Bootstrap Variables
  */
-@import "/lib/bootstrap/less/variables.less";
+@import "../../lib/bootstrap/less/variables.less";
 
 
 // LF colors


### PR DESCRIPTION
Currently using this branch for ModQ and would like to move this into a release version.

The point of this is to allow more flexibility. When each file imports variables.less, you never get the chance to override the variables that it uses. The idea of importing just buttons.less and getting everything it requires was nice, but I regularly find myself then having to write CSS rules that override the default generated CSS rules. It would save me time, frustration, and CSS bloat if I could import variables.less, override the default button colors, then import buttons.less.
Also, there needs to be a variable for the location of twbs (https://github.com/Livefyre/livefyre-bootstrap/blob/oliver_modq/src/styles/all.less#L1), because not all projects are specifying a 'lib' folder in their .bowerrc.
These changes would break your implementation, which is why this needs to be part of a major version bump. Going forward, we'll all need to import variables.less and maybe mixins.less, then override whatever we wish to override, then import buttons.less or popovers.less or whatever it is we want to use.