### PR TITLE
Use variable for bootstrap-less location.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "livefyre-bootstrap",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "main": [
     "./src/main.js"
   ],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "type": "git",
     "url": "https://github.com/Livefyre/livefyre-bootstrap.git"
   },
-  "version": "1.3.8",
+  "version": "1.4.0",
   "scripts": {
     "postinstall": "./node_modules/bower/bin/bower install",
     "start": "./bin/server.js",

--- a/src/styles/all.less
+++ b/src/styles/all.less
@@ -1,8 +1,10 @@
+@bootstrap-less: "/lib/bootstrap/less/";
+
 @import (reference) "./mixins";
 @import (reference) "./variables";
 
 .lf {
-	@import "/lib/bootstrap/less/bootstrap";
+	@import "@{bootstrap-less}/bootstrap";
 
     /**
      * Livefyre stuff

--- a/src/styles/bar.less
+++ b/src/styles/bar.less
@@ -1,4 +1,4 @@
-@import (reference) "/lib/bootstrap/less/navs";
+@import (reference) "@{bootstrap-less}/navs";
 @import (reference) "./mixins";
 @import (reference) "./variables";
 

--- a/src/styles/button-groups.less
+++ b/src/styles/button-groups.less
@@ -1,4 +1,4 @@
-@import (reference) "/lib/bootstrap/less/button-groups";
+@import (reference) "@{bootstrap-less}/button-groups";
 @import (reference) "./variables";
 @import (reference) "./mixins";
 @import (reference) "./buttons";

--- a/src/styles/buttons.less
+++ b/src/styles/buttons.less
@@ -1,4 +1,4 @@
-@import (reference) "/lib/bootstrap/less/buttons";
+@import (reference) "@{bootstrap-less}/buttons";
 @import (reference) "./mixins";
 @import (reference) "./variables";
 

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -1,4 +1,4 @@
-@import (reference) "/lib/bootstrap/less/mixins.less";
+@import (reference) "@{bootstrap-less}/mixins.less";
 
 // Button variants
 // -------------------------

--- a/src/styles/navbar.less
+++ b/src/styles/navbar.less
@@ -1,8 +1,8 @@
 @import (reference) "./mixins";
 @import (reference) "./variables";
-@import (reference) "/lib/bootstrap/less/forms";
-@import (reference) "/lib/bootstrap/less/utilities";
-@import (reference) "/lib/bootstrap/less/navbar";
+@import (reference) "@{bootstrap-less}/forms";
+@import (reference) "@{bootstrap-less}/utilities";
+@import (reference) "@{bootstrap-less}/navbar";
 
 .lf-navbar {
     .navbar;

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -1,8 +1,7 @@
 /**
  * Bootstrap Variables
  */
-@import "/lib/bootstrap/less/variables.less";
-
+@import "@{bootstrap-less}/variables.less";
 
 // LF colors
 // -------------------------


### PR DESCRIPTION
Libraries shouldn't be dependent upon a fixed location for the
underlying bootstrap library. This change switches the location to
a variable that can be set by any consumer.

This is similar to https://github.com/Livefyre/livefyre-bootstrap/pull/105 with the more controversial parts removed. 