### PR TITLE
Fix for modules that import LF-BS variable and mixin files directly

### DIFF
--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -1,3 +1,4 @@
+@bootstrap-less: "/lib/bootstrap/less/"; // Declare here for modules that import this file directly.
 @import (reference) "@{bootstrap-less}/mixins.less";
 
 // Button variants

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -1,6 +1,7 @@
 /**
  * Bootstrap Variables
  */
+@bootstrap-less: "/lib/bootstrap/less/"; // Declare here for modules that import this file directly.
 @import "@{bootstrap-less}/variables.less";
 
 // LF colors


### PR DESCRIPTION
Related: https://github.com/Livefyre/livefyre-bootstrap/commit/b5ecd706181b19b7b7e01638b6919189f7c74a74