### PR TITLE
Added fyrcon-right-*, a way to display fycons :after content.

### DIFF
--- a/src/styles/fycon-styles.less
+++ b/src/styles/fycon-styles.less
@@ -15,23 +15,13 @@
 .fycons-styles() {
   [class^="fycon-"]:before,
   [class*=" fycon-"]:before {
-    font-family: "fycons-@{fycon-font-version}" !important;
-    font-style: normal !important;
-    font-weight: normal !important;
-    font-variant: normal !important;
-    text-transform: none !important;
-    speak: none;
-    line-height: inherit;
-    display: inline-block;
-    vertical-align: middle;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+    .fycons-styles-base();
   }
 
   .btn, .btn-lg, .btn-sm {
     [class^="fycon-"]:before,
     [class*=" fycon-"]:before {
-      margin-top: -2px;
+      .fycons-styles-buttons();
     }
   }
 
@@ -46,4 +36,22 @@
   .fycon-inherit {
     font-size: inherit;
   }
+}
+
+.fycons-styles-base() {
+  font-family: "fycons-@{fycon-font-version}" !important;
+  font-style: normal !important;
+  font-weight: normal !important;
+  font-variant: normal !important;
+  text-transform: none !important;
+  speak: none;
+  line-height: inherit;
+  display: inline-block;
+  vertical-align: middle;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.fycons-styles-buttons() {
+  margin-top: -2px;
 }


### PR DESCRIPTION
This is something that I've had to hack for in ModQ that I would prefer already exist in livefyre-bootstrap, for future maintainability and code reuse.